### PR TITLE
feat: migration de l’entité Task avec formulaire et repository

### DIFF
--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'task')]
+class Task
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'datetime')]
+    private \DateTimeInterface $created_at;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    #[Assert\NotBlank(message: 'Vous devez saisir un titre.')]
+    private ?string $title = null;
+
+    #[ORM\Column(type: 'text')]
+    #[Assert\NotBlank(message: 'Vous devez saisir du contenu.')]
+    private ?string $content = null;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $is_Done = false;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true)] // nullable = “anonyme”
+    private ?User $author = null;
+
+    public function __construct()
+    {
+        $this->created_at = new \DateTimeImmutable();
+        $this->is_Done = false;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getcreated_at(): \DateTimeInterface
+    {
+        return $this->created_at;
+    }
+
+    public function setcreated_at(\DateTimeInterface $created_at): self
+    {
+        $this->created_at = $created_at;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(string $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function is_Done(): bool
+    {
+        return $this->is_Done;
+    }
+
+    public function toggle(bool $flag): self
+    {
+        $this->is_Done = $flag;
+
+        return $this;
+    }
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): self
+    {
+        $this->author = $author;
+        return $this;
+    }
+}

--- a/src/Form/TaskType.php
+++ b/src/Form/TaskType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+class TaskType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('title')
+            ->add('content', TextareaType::class)
+            //->add('author') ===> must be the user authenticated
+        ;
+    }
+}


### PR DESCRIPTION
# Entité Task

Migration de l’entité `Task` :
- Structure et validation
- Création du formulaire `TaskType`

Base prête pour le CRUD des tâches.