### PR TITLE
feat: ajout du contrôleur et des vues pour la gestion des tâches

### DIFF
--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -1,0 +1,120 @@
+<?php
+// src/Controller/TaskController.php
+
+namespace App\Controller;
+
+use App\Entity\Task;
+use App\Form\TaskType;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Doctrine\ORM\EntityManagerInterface;
+
+
+class TaskController extends AbstractController
+{
+    // Liste des tâches
+    public function listAction(ManagerRegistry $doctrine): Response
+    {
+        $tasks = $doctrine->getRepository(Task::class)->findAll();
+
+        return $this->render('task/list.html.twig', [
+            'tasks' => $tasks,
+        ]);
+    }
+
+    // Création d'une nouvelle tâche
+    public function createAction(Request $request, ManagerRegistry $doctrine): Response
+    {
+        $task = new Task();
+        $task->setAuthor($this->getUser()); // null si anonyme
+
+        $form = $this->createForm(TaskType::class, $task);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em = $doctrine->getManager();
+            $em->persist($task);
+            $em->flush();
+
+            $this->addFlash('success', 'La tâche a bien été ajoutée.');
+            return $this->redirectToRoute('task_list');
+        }
+
+        return $this->render('task/create.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    // Édition d'une tâche existante
+    public function editAction(int $id, Request $request, ManagerRegistry $doctrine): Response
+    {
+        $task = $doctrine->getRepository(Task::class)->find($id);
+        if (!$task) {
+            throw $this->createNotFoundException("La tâche #{$id} n'existe pas.");
+        }
+
+        $form = $this->createForm(TaskType::class, $task);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $doctrine->getManager()->flush();
+            $this->addFlash('success', 'La tâche a bien été modifiée.');
+            return $this->redirectToRoute('task_list');
+        }
+
+        return $this->render('task/edit.html.twig', [
+            'form' => $form->createView(),
+            'task' => $task,
+        ]);
+    }
+
+    // Basculer l'état "fait / non fait" d'une tâche
+    public function toggleTaskAction(int $id, ManagerRegistry $doctrine): Response
+    {
+        $task = $doctrine->getRepository(Task::class)->find($id);
+        if (!$task) {
+            throw $this->createNotFoundException("La tâche #{$id} n'existe pas.");
+        }
+
+        $task->toggle(! $task->is_Done());
+        $doctrine->getManager()->flush();
+
+        $this->addFlash('success', sprintf(
+            'La tâche "%s" a bien été marquée comme %s.',
+            $task->getTitle(),
+            $task->is_Done() ? 'faite' : 'non faite'
+        ));
+
+        return $this->redirectToRoute('task_list');
+    }
+
+    // Suppression d'une tâche
+    public function deleteTaskAction(Task $task, EntityManagerInterface $em): Response
+    {
+        $user = $this->getUser();
+
+        // Si l'utilisateur n'est pas connecté, refuse
+        if (!$user) {
+            throw $this->createAccessDeniedException('Vous devez être connecté.');
+        }
+
+        // Si tâche anonyme => seul un admin peut la supprimer
+        if ($task->getAuthor() === null && !$this->isGranted('ROLE_ADMIN')) {
+            throw $this->createAccessDeniedException('Seul un administrateur peut supprimer cette tâche anonyme.');
+        }
+
+        // Si l'utilisateur n'est pas l'auteur et pas admin => refuse
+        if ($task->getAuthor() !== null && $task->getAuthor() !== $user && !$this->isGranted('ROLE_ADMIN')) {
+            throw $this->createAccessDeniedException('Vous ne pouvez supprimer que vos propres tâches.');
+        }
+
+        $em->remove($task);
+        $em->flush();
+
+        $this->addFlash('success', 'La tâche a bien été supprimée.');
+
+        return $this->redirectToRoute('task_list');
+    }
+}

--- a/templates/task/create.html.twig
+++ b/templates/task/create.html.twig
@@ -1,0 +1,13 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <div class="row">
+        {{ form_start(form, {'action' : path('task_create')}) }}
+            {{ form_widget(form) }}
+
+            <button type="submit" class="btn btn-success pull-right">Ajouter</button>
+        {{ form_end(form) }}
+
+        <a href="{{ path('task_list') }}" class="btn btn-primary">Retour à la liste des tâches</a>
+    </div>
+{% endblock %}

--- a/templates/task/edit.html.twig
+++ b/templates/task/edit.html.twig
@@ -1,0 +1,11 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <div class="row">
+        {{ form_start(form, {'action' : path('task_edit', { 'id' : task.id })}) }}
+            {{ form_widget(form) }}
+
+            <button type="submit" class="btn btn-success pull-right">Modifier</button>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/templates/task/list.html.twig
+++ b/templates/task/list.html.twig
@@ -1,0 +1,80 @@
+{% extends 'base.html.twig' %}
+
+{% block header_img %}
+	<img class="slide-image" src="{{ asset('img/todolist_content.jpg') }}" alt="todo list">
+{% endblock %}
+
+{% block body %}
+	<div class="container mt-4">
+		<h1 class="mb-4">Liste des tâches</h1>
+
+		<a href="{{ path('task_create') }}" class="btn btn-info mb-3">Créer une tâche</a>
+
+		{% if app.user and 'ROLE_ADMIN' in app.user.roles %}
+			<a href="{{ path('user_list') }}" class="btn btn-info mb-3">Gestion des utilisateurs</a>
+		{% endif %}
+
+		{% if tasks|length > 0 %}
+			<div class="row">
+				{% for task in tasks %}
+					<div class="col-md-3 mb-4">
+						<div class="card h-100 shadow-sm">
+							<div class="card-body">
+								<h5 class="card-title">
+									<a href="{{ path('task_edit', {'id': task.id}) }}">{{ task.title }}</a>
+								</h5>
+								<p class="card-text">{{ task.content }}</p>
+								<p class="card-text text-muted">
+									<small>Créé par :
+										{% if task.author %}
+											{{ task.author.username }}
+										{% else %}
+											Anonyme
+										{% endif %}
+									</small>
+								</p>
+							</div>
+							<div class="card-footer d-flex justify-content-between align-items-center">
+								<span class="badge bg-{{ task.is_Done ? 'success' : 'secondary' }}">
+									{% if task.is_Done %}
+										<i class="bi bi-check-circle-fill"></i>
+										Faite
+									{% else %}
+										<i class="bi bi-x-circle-fill"></i>
+										À faire
+									{% endif %}
+								</span>
+								<div class="btn-group btn-group-sm" role="group">
+									<form action="{{ path('task_toggle', {'id': task.id}) }}" method="post">
+										<button type="submit" class="btn btn-success w-auto">
+											{% if not task.is_Done %}
+												<i class="bi bi-check2-circle"></i>
+											{% else %}
+												<i class="bi bi-arrow-counterclockwise"></i>
+											{% endif %}
+										</button>
+									</form>
+									{% if app.user and (task.author == app.user or 'ROLE_ADMIN' in app.user.roles) %}
+										<form action="{{ path('task_delete', {'id': task.id}) }}" method="post" onsubmit="return confirm('Voulez-vous vraiment supprimer cette tâche ?');">
+											<button type="submit" class="btn btn-danger w-auto">
+												<i class="bi bi-trash"></i>
+											</button>
+										</form>
+									{% endif %}
+
+								</div>
+							</div>
+						</div>
+					</div>
+
+
+				{% endfor %}
+			</div>
+		{% else %}
+			<div class="alert alert-warning" role="alert">
+				Il n'y a pas encore de tâche enregistrée.
+				<a href="{{ path('task_create') }}" class="btn btn-warning btn-sm ms-2">Créer une tâche</a>
+			</div>
+		{% endif %}
+	</div>
+{% endblock %}


### PR DESCRIPTION
# Contrôleur des tâches

Ajout du `TaskController` avec :
- Routes définies dans `config/routes/task.yaml`
- Méthodes index, create, edit, delete
- Vues Twig associées

Le CRUD des tâches est maintenant opérationnel.
